### PR TITLE
Remove incorrect and unnecessary item from includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=Allows the programmer to use the LED matrix panel as a pixel addressab
 category=Device Control
 url=https://github.com/MajicDesigns/MD_MAXPanel
 architectures=*
-includes=MD_MAXPanel.h, MD_MAX72XX.h
+includes=MD_MAXPanel.h
 license=LGPL-2.1


### PR DESCRIPTION
MD_MAX72XX.h is incorrect because the filename is actually MD_MAX72xx.h. This causes compilation to fail on filename case-sensitive operating systems such as Linux:
```
fatal error: MD_MAX72XX.h: No such file or directory
```
This filename was unnecessary since the `includes` field is only used by Arduino IDE 1.6.10 and newer and those IDE versions do not require dependencies of libraries to be included in the sketch for dependency resolution.